### PR TITLE
Unchecked runtime.lastError Fix

### DIFF
--- a/background.js
+++ b/background.js
@@ -76,6 +76,7 @@ var screenshot = {
                 //return true;
                 break;
             }
+            return true;
         });
     },
     /**


### PR DESCRIPTION
Fix for the Unchecked runtime.lastError error in console when using the extension.
Should close issue #5 